### PR TITLE
Weekly template

### DIFF
--- a/weekly-standup-template.md
+++ b/weekly-standup-template.md
@@ -28,13 +28,6 @@ Please use the template below to report what you have been working on.
 Try to update this as you work.
 
 Please include full details for stories or issues and include links.
-
-Current repos are:
-- alan-turing-institute/data-safe-haven-team#X
-- alan-turing-institute/data-safe-haven#X
-- alan-turing-institute/trusted-research#x
-- sa-tre/satre-specification#X
-- sa-tre/satre-team#X
 -->
 
 <!--
@@ -87,13 +80,6 @@ Other issues can be dealt with in coworking time.
 Please use the template below to report what you expect or want to work on this week.
 
 Please include full details for stories or issues and include links.
-
-Current repos are:
-- alan-turing-institute/data-safe-haven-team#X
-- alan-turing-institute/data-safe-haven#X
-- alan-turing-institute/trusted-research#x
-- sa-tre/satre-specification#X
-- sa-tre/satre-team#X
 -->
 
 <!--

--- a/weekly-standup-template.md
+++ b/weekly-standup-template.md
@@ -41,7 +41,17 @@ Please include full details for stories or issues and include links.
 ### Things that are blocking me
 
 <!--
-Things you'd like to discuss in person with other team members
+Please use the template below to report things that are blocking you.
+This may be things out of your control that you need to raise attention to.
+It may also be things you would like the help or input of the team on.
+-->
+
+<!--
+#### Your name here
+
+- I don't understand bug X
+- I don't feel I have the authority to do Y
+- I want advice on issue Z
 -->
 
 ## Synchronous items

--- a/weekly-standup-template.md
+++ b/weekly-standup-template.md
@@ -27,7 +27,7 @@ Remember to first update the relevant issues and stories on the project board: h
 Please use the template below to report what you have been working on.
 Try to update this as you work.
 
-Please include full details for stories or issues and include links
+Please include full details for stories or issues and include links.
 
 Current repos are:
 - alan-turing-institute/data-safe-haven-team#X
@@ -83,15 +83,21 @@ Other issues can be dealt with in coworking time.
 
 #### Plans for the week
 
-Please include full details for Stories or issues, either link or as org/repo#number
+<!--
+Please use the template below to report what you expect or want to work on this week.
+
+Please include full details for stories or issues and include links.
+
 Current repos are:
 - alan-turing-institute/data-safe-haven-team#X
 - alan-turing-institute/data-safe-haven#X
 - alan-turing-institute/trusted-research#x
 - sa-tre/satre-specification#X
 - sa-tre/satre-team#X
+-->
+
 <!--
-#### Your name here
+##### Your name here
 
 - Work on Story Z
 - by addressing issues X

--- a/weekly-standup-template.md
+++ b/weekly-standup-template.md
@@ -15,9 +15,10 @@ colorlinks: true
 
 ## Asynchronous items
 
-Remember to first update the relevant issues and Stories on GH
 <!--
-Please fill these items out before the meeting
+Please fill these items out before the meeting.
+
+Remember to first update the relevant issues and stories on the project board: https://github.com/orgs/alan-turing-institute/projects/111
 -->
 
 ### What I've done this week

--- a/weekly-standup-template.md
+++ b/weekly-standup-template.md
@@ -23,13 +23,19 @@ Remember to first update the relevant issues and stories on the project board: h
 
 ### What I've done this week
 
-Please include full details for Stories or issues, either link or as org/repo#number
+<!--
+Please use the template below to report what you have been working on.
+Try to update this as you work.
+
+Please include full details for stories or issues and include links
+
 Current repos are:
 - alan-turing-institute/data-safe-haven-team#X
 - alan-turing-institute/data-safe-haven#X
 - alan-turing-institute/trusted-research#x
 - sa-tre/satre-specification#X
 - sa-tre/satre-team#X
+-->
 
 <!--
 #### Your name here

--- a/weekly-standup-template.md
+++ b/weekly-standup-template.md
@@ -59,9 +59,9 @@ It may also be things you would like the help or input of the team on.
 ### Agenda
 
 1. Address blockers
-2. Plan coworking sessions
-3. Plans for the week --- task priotisiation
-4. (Only if needed) Contribute discussion points for Monthly meeting, or elevate decisions
+1. Plan coworking sessions
+1. Plans for the week — task priotisiation
+1. (Only if needed) Contribute discussion points for Monthly meeting, or elevate decisions
 
 <!--
 Please do not add additional agenda items.

--- a/weekly-standup-template.md
+++ b/weekly-standup-template.md
@@ -51,7 +51,7 @@ Current repos are:
 Things you'd like to discuss in person with other team members
 -->
 
-### Pans for the week
+### Plans for the week
 Please include full details for Stories or issues, either link or as org/repo#number
 Current repos are:
 - alan-turing-institute/data-safe-haven-team#X

--- a/weekly-standup-template.md
+++ b/weekly-standup-template.md
@@ -51,7 +51,38 @@ Current repos are:
 Things you'd like to discuss in person with other team members
 -->
 
-### Plans for the week
+## Synchronous items
+
+### Agenda
+
+1. Address blockers
+2. Plan coworking sessions
+3. Plans for the week --- task priotisiation
+4. (Only if needed) Contribute discussion points for Monthly meeting, or elevate decisions
+
+<!--
+Please do not add additional agenda items.
+Other issues can be dealt with in coworking time.
+-->
+
+### Present
+
+- List of people present
+
+### Notes
+
+#### Blockers
+
+- Blocker
+  - Address the blocker
+
+#### Coworking session suggestions
+
+- Suggestion
+- Suggestion
+
+#### Plans for the week
+
 Please include full details for Stories or issues, either link or as org/repo#number
 Current repos are:
 - alan-turing-institute/data-safe-haven-team#X
@@ -66,36 +97,11 @@ Current repos are:
 - by addressing issues X
 -->
 
-## Synchronous items
-
-### Agenda
-
-1. Address blockers
-2. Plan coworking sessions
-3. Consider prioritisation (potentially assign new issues)
-4. (Only if needed) Contribute discussion points for Monthly meeting, or elevate decisions
-
-<!--
-Please do not add additional agenda items.
-Other issues can be dealt with in coworking time.
--->
-
-### Present
-
-- List of people present
-
-### Notes
-
-- Summary of discussion points
-- Use subsections if appropriate
-
-### Decisions
-
-- Record any decisions made during the meeting
-
 ### Actions
 
-| Owner             | Action                               |
-| -------           | --------                             |
-| Meeting organiser | Open meeting record for next meeting |
-| Meeting organiser | Save meeting record (sharepoint)     |
+| Owner                              | Action                                          |
+| -------                            | --------                                        |
+| Meeting organiser                  | Open meeting record for next meeting            |
+| Meeting organiser                  | Save meeting record (sharepoint)                |
+| Technical lead and project manager | Compare actual effort against project board     |
+| Technical lead and project manager | Compare plan for the week against project board |


### PR DESCRIPTION
Updating the weekly the template trying to meet the following principals,

- Keep text minimal
- Simple for the technical team to use
- Useful for technical lead and project manager (and secondarily technical team)
- Integrated (or at least not conflicting) with ways of work

Contributes to #54

I would appreciate your thoughts.

A summary of the changes from the version on main (which isn't what we have used most recently),

- Moving boilerplate text to comments
- Move "plans for this week" to synchronous items
  Don't expect people to plan two weeks in advance
- Add template headers to the notes section
  Reinforce that this meeting should stick quite strictly to the agenda items and not sprawl
- Add regular actions for technical lead and project manager to consider how 'work done' and 'plan for this week' matches with the project board (@Davsarper?)